### PR TITLE
Update German tax rates

### DIFF
--- a/de.xml
+++ b/de.xml
@@ -7,8 +7,8 @@
     <language iso_code="de"/>
   </languages>
   <taxes>
-    <tax id="1" name="MwSt. DE 19%" rate="19" eu-tax-group="virtual"/>
-    <tax id="2" name="MwSt. DE 7%" rate="7"/>
+    <tax id="1" name="MwSt. DE 16%" rate="16" eu-tax-group="virtual"/>
+    <tax id="2" name="MwSt. DE 5%" rate="5"/>
     <tax id="3" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="4" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="5" name="ДДС BG 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>

--- a/de.xml
+++ b/de.xml
@@ -36,7 +36,7 @@
     <tax id="27" name="Moms SE 25%" rate="25" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="28" name="DDV SI 22%" rate="22" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="29" name="DPH SK 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
-    <taxRulesGroup name="DE Standard Rate (19%)">
+    <taxRulesGroup name="DE Standard Rate (16%)">
       <taxRule iso_code_country="be" id_tax="1"/>
       <taxRule iso_code_country="bg" id_tax="1"/>
       <taxRule iso_code_country="cz" id_tax="1"/>
@@ -66,7 +66,7 @@
       <taxRule iso_code_country="se" id_tax="1"/>
       <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
-    <taxRulesGroup name="DE Reduced Rate (7%)">
+    <taxRulesGroup name="DE Reduced Rate (5%)">
       <taxRule iso_code_country="be" id_tax="2"/>
       <taxRule iso_code_country="bg" id_tax="2"/>
       <taxRule iso_code_country="cz" id_tax="2"/>

--- a/de.xml
+++ b/de.xml
@@ -96,7 +96,7 @@
       <taxRule iso_code_country="se" id_tax="2"/>
       <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
-    <taxRulesGroup name="DE Foodstuff Rate (7%)">
+    <taxRulesGroup name="DE Foodstuff Rate (5%)">
       <taxRule iso_code_country="be" id_tax="2"/>
       <taxRule iso_code_country="bg" id_tax="2"/>
       <taxRule iso_code_country="cz" id_tax="2"/>
@@ -126,7 +126,7 @@
       <taxRule iso_code_country="se" id_tax="2"/>
       <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
-    <taxRulesGroup name="DE Books Rate (7%)">
+    <taxRulesGroup name="DE Books Rate (5%)">
       <taxRule iso_code_country="be" id_tax="2"/>
       <taxRule iso_code_country="bg" id_tax="2"/>
       <taxRule iso_code_country="cz" id_tax="2"/>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Update the German tax rates following Angela Merkel's announcement
| Type?         | improvement
| Category?     | LO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes [#19628](https://github.com/PrestaShop/PrestaShop/issues/19628)
| How to test?  | Install the German pack, check that tax rates are 16% instead of 19% and 5% instead of 7%.