### PR TITLE
Update mx.xml

### DIFF
--- a/mx.xml
+++ b/mx.xml
@@ -22,8 +22,8 @@
 	<units>
 		<unit type="weight" value="kg" />
 		<unit type="volume" value="L" />
-		<unit type="short_distance" value="in" />
-		<unit type="base_distance" value="ft" />
-		<unit type="long_distance" value="mi" />
+		<unit type="short_distance" value="cm" />
+		<unit type="base_distance" value="m" />
+		<unit type="long_distance" value="km" />
 	</units>
 </localizationPack>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop Localization files! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | See below
| Fixed ticket? | [Fixes #{23848}] (https://github.com/PrestaShop/PrestaShop/issues/23848)

The localization file `mx.xml` was updated. As explained in the provided ticket, Mexico uses metric system for the units. We expect to see short distance = cm, base distance = m and long distance = km (instead of in, ft, mi).

On March 30, 2020 I created pull request #23830 (https://github.com/PrestaShop/PrestaShop/pull/23830) and created ticket #23848 (https://github.com/PrestaShop/PrestaShop/issues/23848) explaining that in Mexico we use metric system, I provided sources so the team could validate my affirmation:

- http://www.diputados.gob.mx/LeyesBiblio/abro/lfmn/LFMN_abro.pdf
- http://chartsbin.com/view/d12
- https://www.quora.com/Which-countries-do-not-use-the-metric-system

On August 5, 2020 The information was validated by the PrestaShop team and I was suggested to update other repository

>Hi @rickygzz can you please submit your PR against https://github.com/PrestaShop/LocalizationFiles/blob/master/mx.xml ?
> 
> This file here is actually a copy of https://github.com/PrestaShop/LocalizationFiles/blob/master/mx.xml . https://github.com/PrestaShop/LocalizationFiles/blob/master/mx.xml is the reference and we keep a copy inside the software so that, upon install, user does not need to download all files from https://github.com/PrestaShop/LocalizationFiles

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
