### PR TITLE
Added NY, moved DC, added outlying areas AS, GU, MP and UM.

### DIFF
--- a/us.xml
+++ b/us.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <localizationPack name="United States" version="1.0">
-
 	<languages>
 		<language iso_code="en" />
 	</languages>
@@ -229,6 +228,7 @@
 		<state name="Colorado" iso_code="CO" country="US" zone="North America" />
 		<state name="Connecticut" iso_code="CT" country="US" zone="North America" />
 		<state name="Delaware" iso_code="DE" country="US" zone="North America" />
+		<state name="District of Columbia" iso_code="DC" country="US" zone="North America" />
 		<state name="Florida" iso_code="FL" country="US" zone="North America" />
 		<state name="Georgia" iso_code="GA" country="US" zone="North America" />
 		<state name="Hawaii" iso_code="HI" country="US" zone="North America" />
@@ -252,6 +252,7 @@
 		<state name="New Hampshire" iso_code="NH" country="US" zone="North America" />
 		<state name="New Jersey" iso_code="NJ" country="US" zone="North America" />
 		<state name="New Mexico" iso_code="NM" country="US" zone="North America" />
+		<state name="New York" iso_code="NY" country="US" zone="North America" />
 		<state name="North Carolina" iso_code="NC" country="US" zone="North America" />
 		<state name="North Dakota" iso_code="ND" country="US" zone="North America" />
 		<state name="Ohio" iso_code="OH" country="US" zone="North America" />
@@ -270,9 +271,13 @@
 		<state name="West Virginia" iso_code="WV" country="US" zone="North America" />
 		<state name="Wisconsin" iso_code="WI" country="US" zone="North America" />
 		<state name="Wyoming" iso_code="WY" country="US" zone="North America" />
+		<!-- Outlying areas or islands -->
+		<state name="American Samoa" iso_code="AS" country="US" zone="North America" />
+		<state name="Guam" iso_code="GU" country="US" zone="North America" />
+		<state name="Northern Mariana Islands" iso_code="MP" country="US" zone="North America" />
 		<state name="Puerto Rico" iso_code="PR" country="US" zone="North America" />
+		<state name="United States Minor Outlying Islands" iso_code="UM" country="US" zone="North America" />
 		<state name="US Virgin Islands" iso_code="VI" country="US" zone="North America" />
-		<state name="District of Columbia" iso_code="DC" country="US" zone="North America" />
 	</states>
 	<units>
 		<unit type="weight" value="lb" />
@@ -289,4 +294,3 @@
 	</configurations>
 	<group_default price_display_method="1" />
 </localizationPack>
-


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop Localization files! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Read below.
| Fixed ticket? | Fixes #14 (part of it, more PR's are coming :)

Updated \<states> tag according to ISO 3166-2 (https://www.iso.org/obp/ui/#iso:code:3166:US).

- Deleted one empty line.
- Moved District of Columbia alphabetically ordered.
- Added state New York "NY"

- Added outlying areas
-- America Samoa "AS"
-- Guam "GU"
-- Northern Mariana Islands "MP"
-- United States Minor Outlying Islands "UM"

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
