### PR TITLE
Added local accents to states (departments) in co.xml according to ISO 3166-2

### DIFF
--- a/co.xml
+++ b/co.xml
@@ -35,19 +35,19 @@
 		<state name="Amazonas" iso_code="AMA" zone="South America" country="CO"/>
 		<state name="Antioquia" iso_code="ANT" zone="South America" country="CO"/>
 		<state name="Arauca" iso_code="ARA" zone="South America" country="CO"/>
-		<state name="Atlantico" iso_code="ATL" zone="South America" country="CO"/>
-		<state name="Bolivar" iso_code="BOL" zone="South America" country="CO"/>
-		<state name="Boyaca" iso_code="BOY" zone="South America" country="CO"/>
+		<state name="Atlántico" iso_code="ATL" zone="South America" country="CO"/>
+		<state name="Bolívar" iso_code="BOL" zone="South America" country="CO"/>
+		<state name="Boyacá" iso_code="BOY" zone="South America" country="CO"/>
 		<state name="Caldas" iso_code="CAL" zone="South America" country="CO"/>
-		<state name="Caqueta" iso_code="CAQ" zone="South America" country="CO"/>
+		<state name="Caquetá" iso_code="CAQ" zone="South America" country="CO"/>
 		<state name="Casanare" iso_code="CAS" zone="South America" country="CO"/>
 		<state name="Cauca" iso_code="CAU" zone="South America" country="CO"/>
 		<state name="Cesar" iso_code="CES" zone="South America" country="CO"/>
-		<state name="Choco" iso_code="CHO" zone="South America" country="CO"/>
-		<state name="Cordoba" iso_code="COR" zone="South America" country="CO"/>
+		<state name="Chocó" iso_code="CHO" zone="South America" country="CO"/>
+		<state name="Córdoba" iso_code="COR" zone="South America" country="CO"/>
 		<state name="Cundinamarca" iso_code="CUN" zone="South America" country="CO"/>
 		<state name="Distrito Capital" iso_code="DC" zone="South America" country="CO"/>
-		<state name="Guainia" iso_code="GUA" zone="South America" country="CO"/>
+		<state name="Guainía" iso_code="GUA" zone="South America" country="CO"/>
 		<state name="Guaviare" iso_code="GUV" zone="South America" country="CO"/>
 		<state name="Huila" iso_code="HUI" zone="South America" country="CO"/>
 		<state name="La Guajira" iso_code="LAG" zone="South America" country="CO"/>
@@ -56,14 +56,14 @@
 		<state name="Nariño" iso_code="NAR" zone="South America" country="CO"/>
 		<state name="Norte de Santander" iso_code="NSA" zone="South America" country="CO"/>
 		<state name="Putumayo" iso_code="PUT" zone="South America" country="CO"/>
-		<state name="Quindio" iso_code="QUI" zone="South America" country="CO"/>
+		<state name="Quindío" iso_code="QUI" zone="South America" country="CO"/>
 		<state name="Risaralda" iso_code="RIS" zone="South America" country="CO"/>
-		<state name="San Andres y Providencia" iso_code="SAP" zone="South America" country="CO"/>
+		<state name="San Andrés y Providencia" iso_code="SAP" zone="South America" country="CO"/>
 		<state name="Santander" iso_code="SAN" zone="South America" country="CO"/>
 		<state name="Sucre" iso_code="SUC" zone="South America" country="CO"/>
 		<state name="Tolima" iso_code="TOL" zone="South America" country="CO"/>
 		<state name="Valle del Cauca" iso_code="VAC" zone="South America" country="CO"/>
-		<state name="Vaupes" iso_code="VAU" zone="South America" country="CO"/>
+		<state name="Vaupés" iso_code="VAU" zone="South America" country="CO"/>
 		<state name="Vichada" iso_code="VID" zone="South America" country="CO"/>
 	</states>
 </localizationPack>


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop Localization files! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Read below.
| Fixed ticket? | Fixes #14 (part of it, more PR's are coming :)

Modified \<states> tag according to ISO 3166-2 (https://www.iso.org/obp/ui/#iso:code:3166:CO).

Double checked names and ISO codes, everything looked almost fine. They were only missing accents.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
