### PR TITLE
Added states (departments) in py.xml according to ISO 3166-2, updated…

### DIFF
--- a/py.xml
+++ b/py.xml
@@ -18,11 +18,31 @@
 			<taxRule iso_code_country="py" id_tax="2" />
 		</taxRulesGroup>
 	</taxes>
+	<states>
+		<state name="Alto Paraguay" iso_code="16" country="PY" zone="South America" />
+		<state name="Alto Paraná" iso_code="10" country="PY" zone="South America" />
+		<state name="Amambay" iso_code="13" country="PY" zone="South America" />
+		<state name="Asunción" iso_code="ASU" country="PY" zone="South America" />
+		<state name="Boquerón" iso_code="19" country="PY" zone="South America" />
+		<state name="Caaguazú" iso_code="5" country="PY" zone="South America" />
+		<state name="Caazapá" iso_code="6" country="PY" zone="South America" />
+		<state name="Canindeyú" iso_code="14" country="PY" zone="South America" />
+		<state name="Central" iso_code="11" country="PY" zone="South America" />
+		<state name="Concepción" iso_code="1" country="PY" zone="South America" />
+		<state name="Cordillera" iso_code="3" country="PY" zone="South America" />
+		<state name="Guairá" iso_code="4" country="PY" zone="South America" />
+		<state name="Itapúa" iso_code="7" country="PY" zone="South America" />
+		<state name="Misiones" iso_code="8" country="PY" zone="South America" />
+		<state name="Ñeembucú" iso_code="12" country="PY" zone="South America" />
+		<state name="Paraguarí" iso_code="9" country="PY" zone="South America" />
+		<state name="Presidente Hayes" iso_code="15" country="PY" zone="South America" />
+		<state name="San Pedro" iso_code="2" country="PY" zone="South America" />
+	</states>
 	<units>
 		<unit type="weight" value="kg" />
 		<unit type="volume" value="L" />
-		<unit type="short_distance" value="in" />
-		<unit type="base_distance" value="ft" />
-		<unit type="long_distance" value="mi" />
+		<unit type="short_distance" value="cm" />
+		<unit type="base_distance" value="m" />
+		<unit type="long_distance" value="km" />
 	</units>
 </localizationPack>


### PR DESCRIPTION
… metric units.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop Localization files! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Read below.
| Fixed ticket? | Fixes #14 (part of it, more PR's are coming :)

Added \<states> (departments) tag according to ISO 3166-2 (https://www.iso.org/obp/ui/#iso:code:3166:PY).

Also updated distance units to metric system.  (Metric system was adopted in 1899 in Paraguay according to the Government site https://www.mec.gov.py/cms_v2/recursos/6265-adopcion-del-sistema-metrico-decimal-en-la-republica-del-paraguay)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
