### PR TITLE
Updated states (provinces) in cr.xml, missing accents wrong ISO codes…

### DIFF
--- a/cr.xml
+++ b/cr.xml
@@ -23,6 +23,15 @@
       <taxRule iso_code_country="cr" id_tax="3" />
     </taxRulesGroup>
   </taxes>
+  <states>
+    <state name="Alajuela" iso_code="A" country="CR" zone="Central America/Antilla" />
+    <state name="Cartago" iso_code="C" country="CR" zone="Central America/Antilla" />
+    <state name="Guanacaste" iso_code="G" country="CR" zone="Central America/Antilla" />
+    <state name="Heredia" iso_code="H" country="CR" zone="Central America/Antilla" />
+    <state name="Limón" iso_code="L" country="CR" zone="Central America/Antilla" />
+    <state name="Puntarenas" iso_code="P" country="CR" zone="Central America/Antilla" />
+    <state name="San José" iso_code="SJ" country="CR" zone="Central America/Antilla" />
+  </states>
   <units>
     <unit type="weight" value="kg" />
     <unit type="volume" value="L" />
@@ -30,13 +39,4 @@
     <unit type="base_distance" value="m" />
     <unit type="long_distance" value="km" />
   </units>
-  <states>
-    <state name="San Jose" iso_code="CR-SJ" zone="Central America/Antilla" country="CR"/>
-    <state name="Alajuela" iso_code="CR-A" zone="Central America/Antilla" country="CR"/>
-    <state name="Cartago" iso_code="CR-C" zone="Central America/Antilla" country="CR"/>
-    <state name="Heredia" iso_code="CR-H" zone="Central America/Antilla" country="CR"/>
-    <state name="Guanacaste" iso_code="CR-G" zone="Central America/Antilla" country="CR"/>
-    <state name="Puntarenas" iso_code="CR-P" zone="Central America/Antilla" country="CR"/>
-    <state name="Limon" iso_code="CR-L" zone="Central America/Antilla" country="CR"/>
-  </states>
 </localizationPack>


### PR DESCRIPTION
… according to ISO 3166-2.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop Localization files! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Please read below.
| Fixed ticket? | Fixes #14 (part of it, more PR's are coming :)

Updated ISO codes according to ISO 3166-2 (https://www.iso.org/obp/ui/#iso:code:3166:CR), also added missing accents.

Additionally, for standarization purposes compared with the other xml files, the \<states> tag was moved just after the \</taxes> tag. Also, the country attribute was moved before the zones attribute.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
