### PR TITLE
Added states (provinces) to ie.xml according to ISO 3166-2.

### DIFF
--- a/ie.xml
+++ b/ie.xml
@@ -195,6 +195,12 @@
       <taxRule iso_code_country="sk" id_tax="32"/>
     </taxRulesGroup>
   </taxes>
+	<states>
+		<state name="Connaught" iso_code="C" country="IE" zone="Europe" />
+		<state name="Leinster" iso_code="L" country="IE" zone="Europe" />
+		<state name="Munster" iso_code="M" country="IE" zone="Europe" />
+		<state name="Ulster" iso_code="U" country="IE" zone="Europe" />
+	</states>
   <units>
     <unit type="weight" value="kg"/>
     <unit type="volume" value="L"/>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop Localization files! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Please see below.
| Fixed ticket? | Fixes #31 (part of it, more PR's are coming :)

Added \<states> (provinces) tag according to ISO 3166-2 (https://www.iso.org/obp/ui/#iso:code:3166:IE).

To understand why only provinces listed in the ISO website were included, please refer to https://www.dochara.com/the-irish/roots/land-divisions/

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
