### PR TITLE
Normalize long region names for Chile

### DIFF
--- a/cl.xml
+++ b/cl.xml
@@ -14,20 +14,20 @@
 		</taxRulesGroup>
 	</taxes>
 	<states>
-		<state name="Aisén del General Carlos Ibañez del Campo" iso_code="AI" country="CL" zone="South America" />
 		<state name="Antofagasta" iso_code="AN" country="CL" zone="South America" />
 		<state name="Arica y Parinacota" iso_code="AP" country="CL" zone="South America" />
 		<state name="Atacama" iso_code="AT" country="CL" zone="South America" />
+		<state name="Aysén" iso_code="AI" country="CL" zone="South America" />
 		<state name="Biobío" iso_code="BI" country="CL" zone="South America" />
 		<state name="Coquimbo" iso_code="CO" country="CL" zone="South America" />
 		<state name="La Araucanía" iso_code="AR" country="CL" zone="South America" />
-		<state name="Libertador General Bernardo O'Higgins" iso_code="LI" country="CL" zone="South America" />
 		<state name="Los Lagos" iso_code="LL" country="CL" zone="South America" />
 		<state name="Los Ríos" iso_code="LR" country="CL" zone="South America" />
 		<state name="Magallanes" iso_code="MA" country="CL" zone="South America" />
 		<state name="Maule" iso_code="ML" country="CL" zone="South America" />
 		<state name="Ñuble" iso_code="NB" country="CL" zone="South America" />
-		<state name="Región Metropolitana de Santiago" iso_code="RM" country="CL" zone="South America" />
+		<state name="Metrop. de Santiago" iso_code="RM" country="CL" zone="South America" />
+		<state name="O'Higgins" iso_code="LI" country="CL" zone="South America" />
 		<state name="Tarapacá" iso_code="TA" country="CL" zone="South America" />
 		<state name="Valparaíso" iso_code="VS" country="CL" zone="South America" />
 	</states>


### PR DESCRIPTION
Names must be no longer than 32 charaters

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop Localization files! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Used short names for Chilean regions
| Fixed ticket? | Fixes #42 (in part)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
