### PR TITLE
Truncate long names for US states

### DIFF
--- a/us.xml
+++ b/us.xml
@@ -276,7 +276,7 @@
 		<state name="Guam" iso_code="GU" country="US" zone="North America" />
 		<state name="Northern Mariana Islands" iso_code="MP" country="US" zone="North America" />
 		<state name="Puerto Rico" iso_code="PR" country="US" zone="North America" />
-		<state name="United States Minor Outlying Islands" iso_code="UM" country="US" zone="North America" />
+		<state name="US Minor Outlying Islands" iso_code="UM" country="US" zone="North America" />
 		<state name="US Virgin Islands" iso_code="VI" country="US" zone="North America" />
 	</states>
 	<units>


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop Localization files! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Fixed long state name (names should be no longer than 32 characters)
| Fixed ticket? | Fixes #42 (in part) and fixes https://github.com/PrestaShop/PrestaShop/issues/27156

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
