### PR TITLE
Finland tax change 14% to 13.5% on 1.1.2026

### DIFF
--- a/fi.xml
+++ b/fi.xml
@@ -8,7 +8,7 @@
   </languages>
   <taxes>
     <tax id="1" name="ALV FI 25.5%" rate="25.5" eu-tax-group="virtual"/>
-    <tax id="2" name="ALV FI 14%" rate="14"/>
+    <tax id="2" name="ALV FI 13.5%" rate="13.5"/>
     <tax id="3" name="ALV FI 10%" rate="10"/>
     <tax id="4" name="USt. AT 20%" rate="20" auto-generated="1" from-eu-tax-group="virtual"/>
     <tax id="5" name="TVA BE 21%" rate="21" auto-generated="1" from-eu-tax-group="virtual"/>
@@ -69,7 +69,7 @@
       <taxRule iso_code_country="se" id_tax="1"/>
       <taxRule iso_code_country="gb" id_tax="1"/>
     </taxRulesGroup>
-    <taxRulesGroup name="FI Reduced Rate (14%)">
+    <taxRulesGroup name="FI Reduced Rate (13.5%)">
       <taxRule iso_code_country="be" id_tax="2"/>
       <taxRule iso_code_country="bg" id_tax="2"/>
       <taxRule iso_code_country="cz" id_tax="2"/>
@@ -131,7 +131,7 @@
       <taxRule iso_code_country="se" id_tax="3"/>
       <taxRule iso_code_country="gb" id_tax="3"/>
     </taxRulesGroup>
-    <taxRulesGroup name="FI Foodstuff Rate (14%)">
+    <taxRulesGroup name="FI Foodstuff Rate (13.5%)">
       <taxRule iso_code_country="be" id_tax="2"/>
       <taxRule iso_code_country="bg" id_tax="2"/>
       <taxRule iso_code_country="cz" id_tax="2"/>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop Localization files! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Change Finnish VAT rate 14% to 13.5%
| Fixed ticket? | Fixes #57 

Not sure why the current data contains separate "foodstuff" and "reduced" (and "books" and "superreduced") those should probably not be separated as Finland only has 
* regular goods: 25.5%
* books, food, drugs, some transportation services 14% (that is now changing to 13.5%)
* some magazines 10%
* 0%

Source: https://www.vero.fi/yritykset-ja-yhteisot/verot-ja-maksut/arvonlisaverotus/arvonlisaveroprosentit/

**NOTE:** This should not be merged before 1.1.2026 and even then there is still some process to go trough in the government to really do this. Making this PR well in advance as I'm pretty sure this will go trough.

If someone with more knowledge on the import process of these files could tell me should I remove the FoodStuff and BookStuff completely from this?

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
