### PR TITLE
Turkey updated its tax rates on July 10, 2023.

### DIFF
--- a/tr.xml
+++ b/tr.xml
@@ -7,15 +7,15 @@
 		<language iso_code="tr" />
 	</languages>
 	<taxes>
-		<tax id="1" name="KDV TR 18%" rate="18" />
-		<tax id="2" name="KDV TR 8%" rate="8" />
+		<tax id="1" name="KDV TR 20%" rate="20" />
+		<tax id="2" name="KDV TR 10%" rate="10" />
 		<tax id="3" name="KDV TR 1%" rate="1" />
 
-		<taxRulesGroup name="TR Standard Rate (18%)">
+		<taxRulesGroup name="TR Standard Rate (20%)">
 			<taxRule iso_code_country="tr" id_tax="1" />
 		</taxRulesGroup>
 
-		<taxRulesGroup name="TR Reduced Rate (8%)">
+		<taxRulesGroup name="TR Reduced Rate (10%)">
 			<taxRule iso_code_country="tr" id_tax="2" />
 		</taxRulesGroup>
 


### PR DESCRIPTION
Tax rates for Turkey have been changed from 18% to 20% and from 8% to 10% as of July 10, 2023. The 1% tax rate remains unchanged.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop Localization files! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Tax rates for Turkey have been changed from 18% to 20% and from 8% to 10% as of July 10, 2023. The 1% tax rate remains unchanged.
| Fixed ticket? | Fixes #40941

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
