### PR TITLE
Update tax rates and names in ch.xml

### DIFF
--- a/ch.xml
+++ b/ch.xml
@@ -9,19 +9,19 @@
 		<language iso_code="it" />
 	</languages>
 	<taxes>
-		<tax id="1" name="TVA CH 7.7%" rate="7.7" />
-		<tax id="2" name="TVA CH 3.7%" rate="3.7" />
-		<tax id="3" name="TVA CH 2.5%" rate="2.5" />
+		<tax id="1" name="TVA CH 8.1%" rate="8.1" />
+		<tax id="2" name="TVA CH 3.8%" rate="3.8" />
+		<tax id="3" name="TVA CH 2.6%" rate="2.6" />
 
-		<taxRulesGroup name="CH Standard Rate (7.7%)">
+		<taxRulesGroup name="CH Standard Rate (8.1%)">
 			<taxRule iso_code_country="ch" id_tax="1" />
 		</taxRulesGroup>
 
-		<taxRulesGroup name="CH Reduced Rate (3.7%)">
+		<taxRulesGroup name="CH Reduced Rate (3.8%)">
 			<taxRule iso_code_country="ch" id_tax="2" />
 		</taxRulesGroup>
 
-		<taxRulesGroup name="CH Super Reduced Rate (2.5%)">
+		<taxRulesGroup name="CH Super Reduced Rate (2.6%)">
 			<taxRule iso_code_country="ch" id_tax="3" />
 		</taxRulesGroup>
 	</taxes>


### PR DESCRIPTION


<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop Localization files! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Since January 1, 2024, the VAT rates in Switzerland have been increased to 8.1%, 2.6%, and 3.8%. Reference: https://www.estv.admin.ch/de/mwst-steuersaetze-schweiz
| Fixed ticket? | -

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
