### PR TITLE
Fix SK Reduced Rate 2 (5%) tax rule group: correct id_tax from 31 to 3

### DIFF
--- a/sk.xml
+++ b/sk.xml
@@ -101,35 +101,35 @@
       <taxRule iso_code_country="gb" id_tax="2"/>
     </taxRulesGroup>
     <taxRulesGroup name="SK Reduced Rate 2 (5%)">
-      <taxRule iso_code_country="be" id_tax="31"/>
-      <taxRule iso_code_country="bg" id_tax="31"/>
-      <taxRule iso_code_country="cz" id_tax="31"/>
-      <taxRule iso_code_country="dk" id_tax="31"/>
-      <taxRule iso_code_country="de" id_tax="31"/>
-      <taxRule iso_code_country="ee" id_tax="31"/>
-      <taxRule iso_code_country="gr" id_tax="31"/>
-      <taxRule iso_code_country="hr" id_tax="31"/>
-      <taxRule iso_code_country="es" id_tax="31"/>
-      <taxRule iso_code_country="fr" id_tax="31"/>
-      <taxRule iso_code_country="mc" id_tax="31"/>
-      <taxRule iso_code_country="ie" id_tax="31"/>
-      <taxRule iso_code_country="it" id_tax="31"/>
-      <taxRule iso_code_country="cy" id_tax="31"/>
-      <taxRule iso_code_country="lv" id_tax="31"/>
-      <taxRule iso_code_country="lt" id_tax="31"/>
-      <taxRule iso_code_country="lu" id_tax="31"/>
-      <taxRule iso_code_country="hu" id_tax="31"/>
-      <taxRule iso_code_country="mt" id_tax="31"/>
-      <taxRule iso_code_country="nl" id_tax="31"/>
-      <taxRule iso_code_country="at" id_tax="31"/>
-      <taxRule iso_code_country="pl" id_tax="31"/>
-      <taxRule iso_code_country="pt" id_tax="31"/>
-      <taxRule iso_code_country="ro" id_tax="31"/>
-      <taxRule iso_code_country="si" id_tax="31"/>
-      <taxRule iso_code_country="sk" id_tax="31"/>
-      <taxRule iso_code_country="fi" id_tax="31"/>
-      <taxRule iso_code_country="se" id_tax="31"/>
-      <taxRule iso_code_country="gb" id_tax="31"/>
+      <taxRule iso_code_country="be" id_tax="3"/>
+      <taxRule iso_code_country="bg" id_tax="3"/>
+      <taxRule iso_code_country="cz" id_tax="3"/>
+      <taxRule iso_code_country="dk" id_tax="3"/>
+      <taxRule iso_code_country="de" id_tax="3"/>
+      <taxRule iso_code_country="ee" id_tax="3"/>
+      <taxRule iso_code_country="gr" id_tax="3"/>
+      <taxRule iso_code_country="hr" id_tax="3"/>
+      <taxRule iso_code_country="es" id_tax="3"/>
+      <taxRule iso_code_country="fr" id_tax="3"/>
+      <taxRule iso_code_country="mc" id_tax="3"/>
+      <taxRule iso_code_country="ie" id_tax="3"/>
+      <taxRule iso_code_country="it" id_tax="3"/>
+      <taxRule iso_code_country="cy" id_tax="3"/>
+      <taxRule iso_code_country="lv" id_tax="3"/>
+      <taxRule iso_code_country="lt" id_tax="3"/>
+      <taxRule iso_code_country="lu" id_tax="3"/>
+      <taxRule iso_code_country="hu" id_tax="3"/>
+      <taxRule iso_code_country="mt" id_tax="3"/>
+      <taxRule iso_code_country="nl" id_tax="3"/>
+      <taxRule iso_code_country="at" id_tax="3"/>
+      <taxRule iso_code_country="pl" id_tax="3"/>
+      <taxRule iso_code_country="pt" id_tax="3"/>
+      <taxRule iso_code_country="ro" id_tax="3"/>
+      <taxRule iso_code_country="si" id_tax="3"/>
+      <taxRule iso_code_country="sk" id_tax="3"/>
+      <taxRule iso_code_country="fi" id_tax="3"/>
+      <taxRule iso_code_country="se" id_tax="3"/>
+      <taxRule iso_code_country="gb" id_tax="3"/>
     </taxRulesGroup>
     <taxRulesGroup name="EU VAT For Virtual Products" auto-generated="1" eu-tax-group="virtual">
       <taxRule iso_code_country="sk" id_tax="1"/>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop Localization files! 

Please take the time to edit the "Answers" rows below with the necessary information.
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  |  In sk.xml, the taxRulesGroup "**SK Reduced Rate 2 (5%)**" had all 29 taxRule entries pointing to id_tax="31" (**DDV SI 22%, Slovenia's standard rate**) **instead of** id_tax="3" (**DPH SK 5%**). <br>This was probably just a typo. This fix corrects all 29 occurrences in the 5% group from id_tax="31" to the correct id_tax="3". <br> This is a manual fix to SK-specific data only - it doesn't affect the EU VAT virtual tax automation
| Fixed ticket? | No related issue was opened - this typo was found and fixed directly.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
